### PR TITLE
Do not disable menu

### DIFF
--- a/blocks/sg-datalist/sg-datalist.bemhtml
+++ b/blocks/sg-datalist/sg-datalist.bemhtml
@@ -4,8 +4,7 @@ block('sg-datalist')(
             block : 'menu',
             mods : {
                 theme : this.mods.theme,
-                size : this.mods.size,
-                disabled : this.mods.disabled
+                size : this.mods.size
             },
             mix : { block : this.block, js : apply('js') }
         });

--- a/blocks/sg-datalist/sg-datalist.bh.js
+++ b/blocks/sg-datalist/sg-datalist.bh.js
@@ -5,8 +5,7 @@ module.exports = function(bh) {
             block : 'menu',
             mods : {
                 theme : mods.theme,
-                size : mods.size,
-                disabled : mods.disabled
+                size : mods.size
             },
             mix : { block : json.block, js : ctx.js() }
         };


### PR DESCRIPTION
Если у нас изначально есть неактивный инпут с саджестом, то у меню также стоит модификатор `disabled`. Когда мы инпуту удаляем этот модификатор `delMod('disabled')`, то у меню отстутсвует его `tabindex`, так как это зашито в шаблонах bem-components https://github.com/bem/bem-components/blob/v2/common.blocks/menu/menu.bemhtml#L47.
На самом деле, у нас нет необходимости дисэйблить меню, так как у нас все равно нет возможности его вызывать у неактивного инпута.
