### PR TITLE
Fix long item click

### DIFF
--- a/blocks/suggest/suggest.js
+++ b/blocks/suggest/suggest.js
@@ -192,7 +192,6 @@ provide(BemDom.decl(this.name, {
 
     _onPopupPointerPress : function() {
         this._needRefocusControl = true;
-        this.unbindFrom(this._popup.domElem, 'pointerpress', this._onPopupPointerPress);
         this.bindToDoc('pointerrelease', this._refocusControl);
     },
 


### PR DESCRIPTION
See the video: https://yadi.sk/d/jEWThkfnzQwwe

Way to reproduce:
1. It does not reproduce for the first click
2. It reproduces only for long click (press a button and wait a bit before release)

Looks like unbind for focus lost is enough.

// cc @gela-d 